### PR TITLE
Change ENTRYPOINT to CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,4 @@ COPY motd /etc/motd
 RUN echo '\ncat /etc/motd\n' >> /etc/bash.bashrc
 USER ethsec
 
-ENTRYPOINT ["/bin/bash"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
To be able to easily run scripts in a non-interactive way, for
instance:
```
docker run -v ~/workspace/liquity/dev/:/share trailofbits/eth-security-toolbox sh -c "cd /share/packages/contracts/ && python3 slitherTests/find_small_ints.py"
```