### PR TITLE
Fix medusa build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Set Docker metadata
         id: metadata
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -60,7 +60,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Docker Build and Push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64/v8
           target: toolbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ###
 ### Medusa build process
 ###
-FROM golang:1.21 AS medusa
+FROM golang:1.22 AS medusa
 
 WORKDIR /src
 RUN git clone https://github.com/crytic/medusa.git


### PR DESCRIPTION
Medusa now requires Go 1.22+ to build. Update the GitHub actions as well to resolve a warning.