### PR TITLE
Remove hardcoded amd64 echidna reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,8 @@ RUN cd medusa && \
 
 ###
 ### Echidna "build process"
-### TODO: replace this with a aarch64-friendly solution
 ###
-FROM --platform=linux/amd64 ghcr.io/crytic/echidna/echidna:latest AS echidna
+FROM ghcr.io/crytic/echidna/echidna:latest AS echidna
 RUN chmod 755 /usr/local/bin/echidna
 
 


### PR DESCRIPTION
Echidna now also has aarch64 docker containers available.

Closes #22