### PR TITLE
Update GitHub Actions workflow with security improvements and linting

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,18 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3
+        with:
+          dockerfile: Dockerfile
+          ignore: DL3007,DL3008,DL3013,DL3016
+          failure-threshold: warning
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
## Summary
- Add Dockerfile linting to CI pipeline
- Implement security best practices for GitHub Actions
- Update to latest major versions of all actions

## Changes

### 1. Added Checkout Step with Security Configuration
- Added `actions/checkout@v5` with `persist-credentials: false`
- Prevents credentials from persisting in the workspace
- Addresses security recommendation from zizmor audit

### 2. Added Hadolint Dockerfile Linting
- Runs before Docker build to catch issues early
- Configured to ignore intentional choices:
  - `DL3007`: Using `:latest` tag (intentional for echidna)
  - `DL3008`: Unpinned apt packages (flexibility over reproducibility)
  - `DL3013`: Unpinned pip packages (flexibility over reproducibility)
  - `DL3016`: Unpinned npm packages (flexibility over reproducibility)
- Set to fail on warnings to maintain code quality

### 3. Updated Action Versions
- `actions/checkout@v5` - Latest major version (uses Node 24)
- All other actions already on latest major versions:
  - `docker/setup-qemu-action@v3`
  - `docker/setup-buildx-action@v3`
  - `docker/metadata-action@v5`
  - `docker/login-action@v3`
  - `docker/build-push-action@v6`
  - `hadolint/hadolint-action@v3`

## Security Review
- ✅ Reviewed with zizmor security scanner
- ✅ Using major version tags (automatic security updates within major versions)
- ✅ Persist-credentials disabled for checkout
- ✅ No other security issues identified

## Testing
- ✅ YAML syntax validated
- ✅ All action versions verified to exist
- ✅ Hadolint configuration tested locally

This improves CI security and adds quality checks without breaking existing functionality.

🤖 Generated with Claude Code
https://claude.ai/code